### PR TITLE
ttc-connectors-dummytwitter to 1.0.42

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,12 +1,15 @@
 dependencies:
-- name: exposecontroller
-  version: 2.3.58
+- alias: expose
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: expose
-- name: exposecontroller
   version: 2.3.58
+- alias: cleanup
+  name: exposecontroller
   repository: https://chartmuseum.build.cd.jenkins-x.io
-  alias: cleanup
+  version: 2.3.58
 - name: infrastructure
   repository: https://activiti.github.io/activiti-cloud-charts/
   version: 0.2.0
+- name: ttc-connectors-dummytwitter
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.42


### PR DESCRIPTION
Promote ttc-connectors-dummytwitter to version 1.0.42