### PR TITLE
ttc-dashboard-ui to 0.0.37

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -13,3 +13,6 @@ dependencies:
 - name: ttc-connectors-dummytwitter
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.42
+- name: ttc-dashboard-ui
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.37


### PR DESCRIPTION
Promote ttc-dashboard-ui to version 0.0.37